### PR TITLE
Fix style of method names

### DIFF
--- a/proto/com.couchbase.admin.bucket.v1.proto
+++ b/proto/com.couchbase.admin.bucket.v1.proto
@@ -5,15 +5,12 @@ option go_package = "github.com/couchbase/stellar-nebula/genproto/admin_bucket_v
 package com.couchbase.admin.bucket.v1;
 
 service BucketAdmin {
-  rpc ListCollections(ListCollectionsRequest)
-      returns (ListCollectionsResponse) {}
+  rpc list_collections(ListCollectionsRequest) returns (ListCollectionsResponse) {}
 
-  rpc CreateScope(CreateScopeRequest) returns (CreateScopeResponse) {}
-  rpc DeleteScope(DeleteScopeRequest) returns (DeleteScopeResponse) {}
-  rpc CreateCollection(CreateCollectionRequest)
-      returns (CreateCollectionResponse) {}
-  rpc DeleteCollection(DeleteCollectionRequest)
-      returns (DeleteCollectionResponse) {}
+  rpc create_scope(CreateScopeRequest) returns (CreateScopeResponse) {}
+  rpc delete_scope(DeleteScopeRequest) returns (DeleteScopeResponse) {}
+  rpc create_collection(CreateCollectionRequest) returns (CreateCollectionResponse) {}
+  rpc delete_collection(DeleteCollectionRequest) returns (DeleteCollectionResponse) {}
 }
 
 message ListCollectionsRequest { string bucket_name = 1; }

--- a/proto/com.couchbase.analytics.v1.proto
+++ b/proto/com.couchbase.analytics.v1.proto
@@ -7,8 +7,7 @@ package com.couchbase.analytics.v1;
 import "google/protobuf/duration.proto";
 
 service Analytics {
-  rpc AnalyticsQuery(AnalyticsQueryRequest)
-      returns (stream AnalyticsQueryResponse) {}
+  rpc analytics_query(AnalyticsQueryRequest) returns (stream AnalyticsQueryResponse) {}
 }
 
 message AnalyticsQueryRequest {

--- a/proto/com.couchbase.internal.hooks.v1.proto
+++ b/proto/com.couchbase.internal.hooks.v1.proto
@@ -7,15 +7,13 @@ package com.couchbase.internal.hooks.v1;
 import "google/protobuf/any.proto";
 
 service Hooks {
-  rpc CreateHooksContext(CreateHooksContextRequest)
-      returns (CreateHooksContextResponse) {}
-  rpc DestroyHooksContext(DestroyHooksContextRequest)
-      returns (DestroyHooksContextResponse) {}
+  rpc create_hooks_context(CreateHooksContextRequest) returns (CreateHooksContextResponse) {}
+  rpc destroy_hooks_context(DestroyHooksContextRequest) returns (DestroyHooksContextResponse) {}
 
-  rpc AddHooks(AddHooksRequest) returns (AddHooksResponse) {}
+  rpc add_hooks(AddHooksRequest) returns (AddHooksResponse) {}
 
-  rpc WatchBarrier(WatchBarrierRequest) returns (stream WatchBarrierResponse) {}
-  rpc SignalBarrier(SignalBarrierRequest) returns (SignalBarrierResponse) {}
+  rpc watch_barrier(WatchBarrierRequest) returns (stream WatchBarrierResponse) {}
+  rpc signal_barrier(SignalBarrierRequest) returns (SignalBarrierResponse) {}
 }
 
 message CreateHooksContextRequest { string id = 1; }

--- a/proto/com.couchbase.kv.v1.proto
+++ b/proto/com.couchbase.kv.v1.proto
@@ -9,26 +9,26 @@ import "google/protobuf/timestamp.proto";
 import "proto/com.couchbase.v1.proto";
 
 service Kv {
-  rpc Get(GetRequest) returns (GetResponse) {}
-  rpc GetAndTouch(GetAndTouchRequest) returns (GetResponse) {}
-  rpc GetAndLock(GetAndLockRequest) returns (GetResponse) {}
-  rpc Unlock(UnlockRequest) returns (UnlockResponse) {}
-  rpc GetReplica(GetReplicaRequest) returns (GetResponse) {}
-  rpc Touch(TouchRequest) returns (TouchResponse) {}
-  rpc Exists(ExistsRequest) returns (ExistsResponse) {}
+  rpc get(GetRequest) returns (GetResponse) {}
+  rpc get_and_touch(GetAndTouchRequest) returns (GetResponse) {}
+  rpc get_and_lock(GetAndLockRequest) returns (GetResponse) {}
+  rpc unlock(UnlockRequest) returns (UnlockResponse) {}
+  rpc get_replica(GetReplicaRequest) returns (GetResponse) {}
+  rpc touch(TouchRequest) returns (TouchResponse) {}
+  rpc exists(ExistsRequest) returns (ExistsResponse) {}
 
-  rpc Insert(InsertRequest) returns (InsertResponse) {}
-  rpc Upsert(UpsertRequest) returns (UpsertResponse) {}
-  rpc Replace(ReplaceRequest) returns (ReplaceResponse) {}
-  rpc Remove(RemoveRequest) returns (RemoveResponse) {}
-  rpc Increment(IncrementRequest) returns (IncrementResponse) {}
-  rpc Decrement(DecrementRequest) returns (DecrementResponse) {}
-  rpc Append(AppendRequest) returns (AppendResponse) {}
-  rpc Prepend(PrependRequest) returns (PrependResponse) {}
-  rpc LookupIn(LookupInRequest) returns (LookupInResponse) {}
-  rpc MutateIn(MutateInRequest) returns (MutateInResponse) {}
+  rpc insert(InsertRequest) returns (InsertResponse) {}
+  rpc upsert(UpsertRequest) returns (UpsertResponse) {}
+  rpc replace(ReplaceRequest) returns (ReplaceResponse) {}
+  rpc remove(RemoveRequest) returns (RemoveResponse) {}
+  rpc increment(IncrementRequest) returns (IncrementResponse) {}
+  rpc decrement(DecrementRequest) returns (DecrementResponse) {}
+  rpc append(AppendRequest) returns (AppendResponse) {}
+  rpc prepend(PrependRequest) returns (PrependResponse) {}
+  rpc lookup_in(LookupInRequest) returns (LookupInResponse) {}
+  rpc mutate_in(MutateInRequest) returns (MutateInResponse) {}
 
-  rpc RangeScan(RangeScanRequest) returns (RangeScanResponse) {}
+  rpc range_scan(RangeScanRequest) returns (RangeScanResponse) {}
 }
 
 enum DurabilityLevel {

--- a/proto/com.couchbase.query.v1.proto
+++ b/proto/com.couchbase.query.v1.proto
@@ -8,7 +8,7 @@ import "google/protobuf/duration.proto";
 import "proto/com.couchbase.v1.proto";
 
 service Query {
-  rpc Query(QueryRequest) returns (stream QueryResponse) {}
+  rpc query(QueryRequest) returns (stream QueryResponse) {}
 }
 
 message QueryRequest {

--- a/proto/com.couchbase.routing.v1.proto
+++ b/proto/com.couchbase.routing.v1.proto
@@ -5,7 +5,7 @@ option go_package = "github.com/couchbase/stellar-nebula/genproto/routing_v1;rou
 package com.couchbase.routing.v1;
 
 service Routing {
-  rpc WatchRouting(WatchRoutingRequest) returns (stream WatchRoutingResponse) {}
+  rpc watch_routing(WatchRoutingRequest) returns (stream WatchRoutingResponse) {}
 }
 
 message RoutingEndpoint {

--- a/proto/com.couchbase.search.v1.proto
+++ b/proto/com.couchbase.search.v1.proto
@@ -209,7 +209,7 @@ message Sorting {
 }
 
 service Search {
-  rpc SearchQuery(SearchQueryRequest) returns (stream SearchQueryResponse) {}
+  rpc search_query(SearchQueryRequest) returns (stream SearchQueryResponse) {}
 }
 
 message SearchQueryRequest {

--- a/proto/com.couchbase.transactions.v1.proto
+++ b/proto/com.couchbase.transactions.v1.proto
@@ -5,20 +5,14 @@ option go_package = "github.com/couchbase/stellar-nebula/genproto/transactions_v
 package com.couchbase.transactions.v1;
 
 service Transactions {
-  rpc TransactionBeginAttempt(TransactionBeginAttemptRequest)
-      returns (TransactionBeginAttemptResponse) {}
-  rpc TransactionCommit(TransactionCommitRequest)
-      returns (TransactionCommitResponse) {}
-  rpc TransactionRollback(TransactionRollbackRequest)
-      returns (TransactionRollbackResponse) {}
+  rpc transaction_begin_attempt(TransactionBeginAttemptRequest) returns (TransactionBeginAttemptResponse) {}
+  rpc transaction_commit(TransactionCommitRequest) returns (TransactionCommitResponse) {}
+  rpc transaction_rollback(TransactionRollbackRequest) returns (TransactionRollbackResponse) {}
 
-  rpc TransactionGet(TransactionGetRequest) returns (TransactionGetResponse) {}
-  rpc TransactionInsert(TransactionInsertRequest)
-      returns (TransactionInsertResponse) {}
-  rpc TransactionReplace(TransactionReplaceRequest)
-      returns (TransactionReplaceResponse) {}
-  rpc TransactionRemove(TransactionRemoveRequest)
-      returns (TransactionRemoveResponse) {}
+  rpc transaction_get(TransactionGetRequest) returns (TransactionGetResponse) {}
+  rpc transaction_insert(TransactionInsertRequest) returns (TransactionInsertResponse) {}
+  rpc transaction_replace(TransactionReplaceRequest) returns (TransactionReplaceResponse) {}
+  rpc transaction_remove(TransactionRemoveRequest) returns (TransactionRemoveResponse) {}
 }
 
 message TransactionBeginAttemptRequest {

--- a/proto/com.couchbase.view.v1.proto
+++ b/proto/com.couchbase.view.v1.proto
@@ -5,7 +5,7 @@ option go_package = "github.com/couchbase/stellar-nebula/genproto/view_v1;view_v
 package com.couchbase.view.v1;
 
 service View {
-  rpc ViewQuery(ViewQueryRequest) returns (stream ViewQueryResponse) {}
+  rpc view_query(ViewQueryRequest) returns (stream ViewQueryResponse) {}
 }
 
 message ViewQueryRequest {


### PR DESCRIPTION
Otherwise it generates ugly names for C++ and Ruby.

According to protobuf spec here:
https://developers.google.com/protocol-buffers/docs/style#message_and_field_names

> Use CamelCase (with an initial capital) for message names -- for
> example, SongServerRequest. Use underscore_separated_names for
> field names (including oneof field and extension names)

Also field name changes do not affect the wire format. See: https://developers.google.com/protocol-buffers/docs/encoding#structure

> The binary version of a message just uses the field's number
> as the key -- the name and declared type for each field can
> only be determined on the decoding end by referencing the message
> type's definition (that is, the .proto file).