### PR TITLE
"optional" is removed as a keyword in proto3 syntax

### DIFF
--- a/proto/couchbase/admin/bucket.v1.proto
+++ b/proto/couchbase/admin/bucket.v1.proto
@@ -72,14 +72,14 @@ message CreateBucketRequest {
   BucketType bucket_type = 2;
   uint64 ram_quota_bytes = 3;
   uint32 num_replicas = 4;
-  optional bool flush_enabled = 5;
-  optional bool replica_indexes = 6;
-  optional EvictionMode eviction_mode = 7;
-  optional uint32 max_expiry_secs = 8;
-  optional CompressionMode compression_mode = 9;
-  optional couchbase.kv.v1.DurabilityLevel minimum_durability_level = 10;
-  optional StorageBackend storage_backend = 11;
-  optional ConflictResolutionType conflict_resolution_type = 12;
+  /* optional */ bool flush_enabled = 5;
+  /* optional */ bool replica_indexes = 6;
+  /* optional */ EvictionMode eviction_mode = 7;
+  /* optional */ uint32 max_expiry_secs = 8;
+  /* optional */ CompressionMode compression_mode = 9;
+  /* optional */ couchbase.kv.v1.DurabilityLevel minimum_durability_level = 10;
+  /* optional */ StorageBackend storage_backend = 11;
+  /* optional */ ConflictResolutionType conflict_resolution_type = 12;
 }
 
 message CreateBucketResponse { string bucket_uuid = 1; }
@@ -87,16 +87,16 @@ message CreateBucketResponse { string bucket_uuid = 1; }
 message UpdateBucketRequest {
   string bucket_name = 1;
   reserved 2; // bucket_type
-  optional uint64 ram_quota_bytes = 3;
-  optional uint32 num_replicas = 4;
-  optional bool flush_enabled = 5;
-  optional bool replica_indexes = 6;
-  optional EvictionMode eviction_mode = 7;
-  optional uint32 max_expiry_secs = 8;
-  optional CompressionMode compression_mode = 9;
-  optional couchbase.kv.v1.DurabilityLevel minimum_durability_level = 10;
+  /* optional */ uint64 ram_quota_bytes = 3;
+  /* optional */ uint32 num_replicas = 4;
+  /* optional */ bool flush_enabled = 5;
+  /* optional */ bool replica_indexes = 6;
+  /* optional */ EvictionMode eviction_mode = 7;
+  /* optional */ uint32 max_expiry_secs = 8;
+  /* optional */ CompressionMode compression_mode = 9;
+  /* optional */ couchbase.kv.v1.DurabilityLevel minimum_durability_level = 10;
   reserved 11; // storage_backend
-  optional ConflictResolutionType conflict_resolution_type = 12;
+  /* optional */ ConflictResolutionType conflict_resolution_type = 12;
 }
 
 message UpdateBucketResponse {}

--- a/proto/couchbase/analytics.v1.proto
+++ b/proto/couchbase/analytics.v1.proto
@@ -14,19 +14,19 @@ service Analytics {
 }
 
 message AnalyticsQueryRequest {
-  optional string bucket_name = 8;
-  optional string scope_name = 9;
+  /* optional */ string bucket_name = 8;
+  /* optional */ string scope_name = 9;
   string statement = 1;
 
-  optional bool read_only = 2;
-  optional string client_context_id = 3;
-  optional bool priority = 4;
+  /* optional */ bool read_only = 2;
+  /* optional */ string client_context_id = 3;
+  /* optional */ bool priority = 4;
 
   enum ScanConsistency {
     NOT_BOUNDED = 0;
     REQUEST_PLUS = 1;
   }
-  optional ScanConsistency scan_consistency = 5;
+  /* optional */ ScanConsistency scan_consistency = 5;
   repeated bytes positional_parameters = 6;
   map<string, bytes> named_parameters = 7;
 }
@@ -59,5 +59,5 @@ message AnalyticsQueryResponse {
     repeated Warning warnings = 5;
     string status = 6;
   }
-  optional MetaData meta_data = 2;
+  /* optional */ MetaData meta_data = 2;
 }

--- a/proto/couchbase/internal/hooks.v1.proto
+++ b/proto/couchbase/internal/hooks.v1.proto
@@ -115,7 +115,7 @@ message WatchBarrierResponse { string wait_id = 2; }
 message SignalBarrierRequest {
   string hooks_context_id = 1;
   string barrier_id = 2;
-  optional string wait_id = 3;
+  /* optional */ string wait_id = 3;
 }
 
 message SignalBarrierResponse {}

--- a/proto/couchbase/kv.v1.proto
+++ b/proto/couchbase/kv.v1.proto
@@ -103,7 +103,7 @@ message GetResponse {
   DocumentContentType content_type = 2;
   DocumentCompressionType compression_type = 5;
   uint64 cas = 3;
-  google.protobuf.Timestamp expiry = 4;
+  /* optional */ google.protobuf.Timestamp expiry = 4;
 }
 
 message UnlockRequest {
@@ -148,7 +148,7 @@ message InsertRequest {
   string key = 4;
   bytes content = 5;
   DocumentContentType content_type = 6;
-  google.protobuf.Timestamp expiry = 7;
+  /* optional */ google.protobuf.Timestamp expiry = 7;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 8;
     DurabilityLevel durability_level = 9;
@@ -167,7 +167,7 @@ message UpsertRequest {
   string key = 4;
   bytes content = 5;
   DocumentContentType content_type = 6;
-  google.protobuf.Timestamp expiry = 7;
+  /* optional */ google.protobuf.Timestamp expiry = 7;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 8;
     DurabilityLevel durability_level = 9;
@@ -186,8 +186,8 @@ message ReplaceRequest {
   string key = 4;
   bytes content = 5;
   DocumentContentType content_type = 6;
-  uint64 cas = 7;
-  google.protobuf.Timestamp expiry = 8;
+  /* optional */ uint64 cas = 7;
+  /* optional */ google.protobuf.Timestamp expiry = 8;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 9;
     DurabilityLevel durability_level = 10;
@@ -204,7 +204,7 @@ message RemoveRequest {
   string scope_name = 2;
   string collection_name = 3;
   string key = 4;
-  uint64 cas = 5;
+  /* optional */ uint64 cas = 5;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 6;
     DurabilityLevel durability_level = 7;
@@ -222,8 +222,8 @@ message IncrementRequest {
   string collection_name = 3;
   string key = 4;
   uint64 delta = 5;
-  google.protobuf.Timestamp expiry = 6;
-  int64 initial = 7;
+  /* optional */ google.protobuf.Timestamp expiry = 6;
+  /* optional */ int64 initial = 7;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 8;
     DurabilityLevel durability_level = 9;
@@ -242,8 +242,8 @@ message DecrementRequest {
   string collection_name = 3;
   string key = 4;
   uint64 delta = 5;
-  google.protobuf.Timestamp expiry = 6;
-  int64 initial = 7;
+  /* optional */ google.protobuf.Timestamp expiry = 6;
+  /* optional */ int64 initial = 7;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 8;
     DurabilityLevel durability_level = 9;
@@ -262,7 +262,7 @@ message AppendRequest {
   string collection_name = 3;
   string key = 4;
   bytes content = 5;
-  uint64 cas = 6;
+  /* optional */ uint64 cas = 6;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 7;
     DurabilityLevel durability_level = 8;
@@ -280,7 +280,7 @@ message PrependRequest {
   string collection_name = 3;
   string key = 4;
   bytes content = 5;
-  uint64 cas = 6;
+  /* optional */ uint64 cas = 6;
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 7;
     DurabilityLevel durability_level = 8;
@@ -308,14 +308,14 @@ message LookupInRequest {
 
     string path = 2;
 
-    message Flags { bool xattr = 1; }
-    Flags flags = 3;
+    message Flags { /* optional */ bool xattr = 1; }
+    /* optional */ Flags flags = 3;
   }
 
   repeated Spec specs = 5;
 
-  message Flags { bool access_deleted = 1; }
-  Flags flags = 6;
+  message Flags { /* optional */ bool access_deleted = 1; }
+  /* optional */ Flags flags = 6;
 }
 
 message LookupInResponse {
@@ -352,10 +352,10 @@ message MutateInRequest {
     bytes content = 3;
 
     message Flags {
-      bool create_path = 1;
-      bool xattr = 2;
+      /* optional */ bool create_path = 1;
+      /* optional */ bool xattr = 2;
     }
-    Flags flags = 4;
+    /* optional */ Flags flags = 4;
   }
 
   repeated Spec specs = 5;
@@ -365,21 +365,21 @@ message MutateInRequest {
     UPSERT = 1;
     INSERT = 2;
   }
-  StoreSemantic store_semantic = 6;
+  /* optional */ StoreSemantic store_semantic = 6;
 
   oneof durability_spec {
     LegacyDurabilitySpec legacy_durability_spec = 7;
     DurabilityLevel durability_level = 8;
   }
 
-  uint64 cas = 9;
+  /* optional */ uint64 cas = 9;
 
-  message Flags { bool access_deleted = 1; }
-  Flags flags = 10;
+  message Flags { /* optional */ bool access_deleted = 1; }
+  /* optional */ Flags flags = 10;
 }
 
 message MutateInResponse {
-  message Spec { bytes content = 1; }
+  message Spec { /* optional */ bytes content = 1; }
   repeated Spec specs = 1;
 
   uint64 cas = 2;
@@ -419,7 +419,7 @@ message RangeScanResponse {
   message Document {
     message MetaData {
       uint32 flags = 1;
-      google.protobuf.Timestamp expiry = 2;
+      /* optional */ google.protobuf.Timestamp expiry = 2;
       uint64 seqno = 3;
       uint64 cas = 4;
       DocumentContentType content_type = 5;
@@ -427,8 +427,8 @@ message RangeScanResponse {
     }
 
     string key = 1;
-    bytes content = 2;
-    MetaData meta_data = 3;
+    /* optional */ bytes content = 2;
+    /* optional */ MetaData meta_data = 3;
   }
 
   repeated Document documents = 1;

--- a/proto/couchbase/query.v1.proto
+++ b/proto/couchbase/query.v1.proto
@@ -14,34 +14,34 @@ service Query {
 }
 
 message QueryRequest {
-  optional string bucket_name = 1;
-  optional string scope_name = 2;
+  /* optional */ string bucket_name = 1;
+  /* optional */ string scope_name = 2;
   string statement = 3;
 
-  optional bool read_only = 4;
-  optional bool prepared = 5;
+  /* optional */ bool read_only = 4;
+  /* optional */ bool prepared = 5;
 
   message TuningOptions {
-    optional uint32 max_parallelism = 1;
-    optional uint32 pipeline_batch = 2;
-    optional uint32 pipeline_cap = 3;
-    optional google.protobuf.Duration scan_wait = 4;
-    optional uint32 scan_cap = 5;
-    optional bool disable_metrics = 6;
+    /* optional */ uint32 max_parallelism = 1;
+    /* optional */ uint32 pipeline_batch = 2;
+    /* optional */ uint32 pipeline_cap = 3;
+    /* optional */ google.protobuf.Duration scan_wait = 4;
+    /* optional */ uint32 scan_cap = 5;
+    /* optional */ bool disable_metrics = 6;
   }
-  optional TuningOptions tuning_options = 6;
+  /* optional */ TuningOptions tuning_options = 6;
 
-  optional string client_context_id = 7;
+  /* optional */ string client_context_id = 7;
 
   enum QueryScanConsistency {
     NOT_BOUNDED = 0;
     REQUEST_PLUS = 1;
   }
-  optional QueryScanConsistency scan_consistency = 8;
+  /* optional */ QueryScanConsistency scan_consistency = 8;
   repeated bytes positional_parameters = 9;
   map<string, bytes> named_parameters = 10;
-  optional bool flex_index = 11;
-  optional bool preserve_expiry = 12;
+  /* optional */ bool flex_index = 11;
+  /* optional */ bool preserve_expiry = 12;
   repeated couchbase.kv.v1.MutationToken consistent_with = 13;
 
   enum QueryProfileMode {
@@ -49,7 +49,7 @@ message QueryRequest {
     PHASES = 1;
     TIMINGS = 2;
   }
-  optional QueryProfileMode profile_mode = 14;
+  /* optional */ QueryProfileMode profile_mode = 14;
 }
 
 message QueryResponse {
@@ -87,11 +87,11 @@ message QueryResponse {
       uint64 error_count = 7;
       uint64 warning_count = 8;
     }
-    optional Metrics metrics = 3;
+    /* optional */ Metrics metrics = 3;
     MetaDataStatus status = 4;
     repeated Warning warnings = 5;
-    optional bytes profile = 6;
+    /* optional */ bytes profile = 6;
     bytes signature = 7;
   }
-  optional MetaData meta_data = 2;
+  /* optional */ MetaData meta_data = 2;
 }

--- a/proto/couchbase/routing.v1.proto
+++ b/proto/couchbase/routing.v1.proto
@@ -37,7 +37,7 @@ message ViewsRouting { repeated ViewsRoutingEndpoint endpoints = 1; }
 
 message WatchRoutingRequest {
   // Specifies the specific bucket that will be accessed.
-  optional string bucket_name = 1;
+  /* optional */ string bucket_name = 1;
 }
 
 message WatchRoutingResponse {
@@ -56,6 +56,6 @@ message WatchRoutingResponse {
   repeated RoutingEndpoint endpoints = 2;
 
   oneof data_routing { VbucketDataRoutingStrategy vbucket_data_routing = 3; }
-  optional QueryRouting query_routing = 4;
-  optional ViewsRouting views_routing = 5;
+  /* optional */ QueryRouting query_routing = 4;
+  /* optional */ ViewsRouting views_routing = 5;
 }

--- a/proto/couchbase/search.v1.proto
+++ b/proto/couchbase/search.v1.proto
@@ -252,5 +252,5 @@ message SearchQueryResponse {
     // errors
     // facets
   }
-  optional MetaData meta_data = 2;
+  /* optional */ MetaData meta_data = 2;
 }

--- a/proto/couchbase/transactions.v1.proto
+++ b/proto/couchbase/transactions.v1.proto
@@ -25,7 +25,7 @@ service Transactions {
 
 message TransactionBeginAttemptRequest {
   string bucket_name = 1;
-  optional string transaction_id = 2;
+  /* optional */ string transaction_id = 2;
 }
 
 message TransactionBeginAttemptResponse {

--- a/proto/couchbase/view.v1.proto
+++ b/proto/couchbase/view.v1.proto
@@ -15,8 +15,8 @@ message ViewQueryRequest {
   string design_document_name = 1;
   string view_name = 2;
 
-  optional uint32 skip = 3;
-  optional uint32 limit = 4;
+  /* optional */ uint32 skip = 3;
+  /* optional */ uint32 limit = 4;
 
   enum ScanConsistency {
     NOT_BOUNDED = 0;
@@ -35,21 +35,21 @@ message ViewQueryRequest {
     ASCENDING = 0;
     DESCENDING = 1;
   }
-  optional ScanConsistency scan_consistency = 5;
-  optional bool reduce = 6;
-  optional bool group = 7;
-  optional uint32 group_level = 9;
-  optional bytes key = 10;
+  /* optional */ ScanConsistency scan_consistency = 5;
+  /* optional */ bool reduce = 6;
+  /* optional */ bool group = 7;
+  /* optional */ uint32 group_level = 9;
+  /* optional */ bytes key = 10;
   repeated bytes keys = 11;
-  optional bytes start_key = 12;
-  optional bytes end_key = 13;
-  optional bool inclusive_end = 14;
-  optional string start_key_doc_id = 15;
-  optional string end_key_doc_id = 16;
-  optional ErrorMode on_error = 17;
-  optional bool debug = 18;
-  optional DesignDocumentNamespace namespace = 19;
-  optional Order order = 20;
+  /* optional */ bytes start_key = 12;
+  /* optional */ bytes end_key = 13;
+  /* optional */ bool inclusive_end = 14;
+  /* optional */ string start_key_doc_id = 15;
+  /* optional */ string end_key_doc_id = 16;
+  /* optional */ ErrorMode on_error = 17;
+  /* optional */ bool debug = 18;
+  /* optional */ DesignDocumentNamespace namespace = 19;
+  /* optional */ Order order = 20;
 }
 
 message ViewQueryResponse {
@@ -64,5 +64,5 @@ message ViewQueryResponse {
     uint64 total_rows = 1;
     bytes debug = 2;
   }
-  optional MetaData meta_data = 2;
+  /* optional */ MetaData meta_data = 2;
 }


### PR DESCRIPTION
Version 2 of the spec contains optional:
  https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#fields

Version 3 of the spec does _NOT_ contain optional:
https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#fields