### PR TITLE
Implemented a basic grpc health check

### DIFF
--- a/gateway/system/health.go
+++ b/gateway/system/health.go
@@ -1,0 +1,21 @@
+package system
+
+import (
+	"context"
+
+	"github.com/couchbase/stellar-nebula/genproto/health_v1"
+)
+
+// health server, it piggy backs on data since its publically exposed.
+type HealthV1Server struct {
+	health_v1.UnimplementedHealthServer
+}
+
+func (s HealthV1Server) Check(ctx context.Context, req *health_v1.HealthCheckRequest) (*health_v1.HealthCheckResponse, error) {
+	return &health_v1.HealthCheckResponse{
+		Status: health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+func (s HealthV1Server) Watch(req *health_v1.HealthCheckRequest, server health_v1.Health_WatchServer) error {
+	return server.Send(&health_v1.HealthCheckResponse{Status: health_v1.HealthCheckResponse_SERVING})
+}

--- a/gateway/system/system.go
+++ b/gateway/system/system.go
@@ -13,6 +13,7 @@ import (
 	"github.com/couchbase/stellar-nebula/genproto/admin_bucket_v1"
 	"github.com/couchbase/stellar-nebula/genproto/admin_collection_v1"
 	"github.com/couchbase/stellar-nebula/genproto/analytics_v1"
+	"github.com/couchbase/stellar-nebula/genproto/health_v1"
 	"github.com/couchbase/stellar-nebula/genproto/internal_hooks_v1"
 	"github.com/couchbase/stellar-nebula/genproto/kv_v1"
 	"github.com/couchbase/stellar-nebula/genproto/query_v1"
@@ -57,6 +58,9 @@ func NewSystem(opts *SystemOptions) (*System, error) {
 	admin_bucket_v1.RegisterBucketAdminServer(dataSrv, dataImpl.AdminBucketV1Server)
 	admin_collection_v1.RegisterCollectionAdminServer(dataSrv, dataImpl.AdminCollectionV1Server)
 	transactions_v1.RegisterTransactionsServer(dataSrv, dataImpl.TransactionsV1Server)
+
+	// health check
+	health_v1.RegisterHealthServer(dataSrv, HealthV1Server{})
 
 	sdSrv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(hooksManager.UnaryInterceptor(), metricsInterceptor.UnaryConnectionCounterInterceptor),

--- a/generate-protos.go
+++ b/generate-protos.go
@@ -10,5 +10,6 @@
 //go:generate protostellar couchbase/admin/bucket.v1.proto
 //go:generate protostellar couchbase/admin/collection.v1.proto
 //go:generate protostellar couchbase/internal/hooks.v1.proto
+//go:generate protostellar couchbase/internal/health.v1.proto
 
 package main

--- a/proto/couchbase/internal/health.v1.proto
+++ b/proto/couchbase/internal/health.v1.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package couchbase.health.v1;
+
+option go_package = "github.com/couchbase/stellar-nebula/genproto/health_v1;health_v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
Kubernetes supports a native grpc health check.
See: https://github.com/grpc/grpc/blob/master/doc/health-checking.md

This change introduces the basic requirements to meet this spec.