### PR TITLE
ING-384 - Gateway should restart on failure

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -21,6 +21,7 @@ var cbPass = flag.String("cb-pass", "password", "the couchbase server password")
 var dataPort = flag.Int("data-port", 18098, "the data port")
 var sdPort = flag.Int("sd-port", 18099, "the sd port")
 var webPort = flag.Int("web-port", 9091, "the web metrics/health port")
+var daemon = flag.Bool("daemon", false, "When in daemon mode, stellar-gateway will restart on failure")
 
 func main() {
 	flag.Parse()
@@ -54,6 +55,7 @@ func main() {
 		CbConnStr:    *cbHost,
 		Username:     *cbUser,
 		Password:     *cbPass,
+		Daemon:       *daemon,
 		BindDataPort: *dataPort,
 		BindSdPort:   *sdPort,
 		BindAddress:  "0.0.0.0",

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -35,6 +35,7 @@ type Config struct {
 	Logger      *zap.Logger
 	NodeID      string
 	ServerGroup string
+	Daemon bool
 
 	CbConnStr string
 	Username  string
@@ -249,7 +250,12 @@ func gatewayStartup(ctx context.Context, config *Config) error {
 func Run(ctx context.Context, config *Config) {
 	startupCount := 1
 	err := gatewayStartup(context.Background(), config)
+	//TODO(malscent): daemon mode should start up grpc servers and return errors to client specifying issues connecting to underlying service instead of just restarting whole process
 	for err != nil {
+		if !config.Daemon {
+			config.Logger.Warn("Daemon mode disabled, exiting.", zap.Error(err))
+			return
+		}
 		config.Logger.Warn("Startup of gateway failed.  Retrying...", zap.Int("attempts", startupCount), zap.Duration("interval", time.Second*time.Duration(startupCount)), zap.Error(err))
 		time.Sleep(time.Second * time.Duration(startupCount))
 		startupCount++


### PR DESCRIPTION
  * When gateway starts up, the servers it connect to may not be ready yet, so it should retry indefinitely.  If there is an issue, Operator's health check will address