### PR TITLE
Set correct MutateIn/LookupIn op types when path is empty in Get, Replace, Remove

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -857,9 +857,17 @@ func (s *KvServer) MutateIn(ctx context.Context, in *kv_v1.MutateInRequest) (*kv
 		case kv_v1.MutateInRequest_Spec_OPERATION_UPSERT:
 			op = memdx.MutateInOpTypeDictSet
 		case kv_v1.MutateInRequest_Spec_OPERATION_REPLACE:
-			op = memdx.MutateInOpTypeReplace
+			if spec.Path == "" {
+				op = memdx.MutateInOpTypeSetDoc
+			} else {
+				op = memdx.MutateInOpTypeReplace
+			}
 		case kv_v1.MutateInRequest_Spec_OPERATION_REMOVE:
-			op = memdx.MutateInOpTypeDelete
+			if spec.Path == "" {
+				op = memdx.MutateInOpTypeDeleteDoc
+			} else {
+				op = memdx.MutateInOpTypeDelete
+			}
 		case kv_v1.MutateInRequest_Spec_OPERATION_INSERT:
 			op = memdx.MutateInOpTypeDictAdd
 		case kv_v1.MutateInRequest_Spec_OPERATION_COUNTER:

--- a/gateway/test/crud_test.go
+++ b/gateway/test/crud_test.go
@@ -1643,6 +1643,19 @@ func (s *GatewayOpsTestSuite) TestMutateIn() {
 			checkDocumentPath(docId, "foo", []byte(`"baz"`))
 		})
 
+		s.Run("ReplaceEmptyPath", func() {
+			docId := s.binaryDocId([]byte(`{"foo": 14}`))
+			content := []byte(`{"bar": 28}`)
+
+			testBasicSpec(docId, &kv_v1.MutateInRequest_Spec{
+				Operation: kv_v1.MutateInRequest_Spec_OPERATION_REPLACE,
+				Path:      "",
+				Content:   content,
+			})
+
+			checkDocumentPath(docId, "", content)
+		})
+
 		s.Run("Remove", func() {
 			docId := s.binaryDocId([]byte(`{"foo": 14}`))
 
@@ -1652,6 +1665,24 @@ func (s *GatewayOpsTestSuite) TestMutateIn() {
 			})
 
 			checkDocumentPath(docId, "foo", nil)
+		})
+
+		s.Run("RemoveEmptyPath", func() {
+			docId := s.binaryDocId([]byte(`{"foo": 14}`))
+
+			testBasicSpec(docId, &kv_v1.MutateInRequest_Spec{
+				Operation: kv_v1.MutateInRequest_Spec_OPERATION_REMOVE,
+				Path:      "",
+			})
+
+			_, err := kvClient.Get(context.Background(), &kv_v1.GetRequest{
+				BucketName:     s.bucketName,
+				ScopeName:      s.scopeName,
+				CollectionName: s.collectionName,
+				Key:            docId,
+			}, grpc.PerRPCCredentials(s.basicRpcCreds))
+
+			assertRpcStatus(s.T(), err, codes.NotFound)
 		})
 
 		s.Run("ArrayAppend", func() {


### PR DESCRIPTION
Fixes error when doing a LookupIn get with an empty path (gocbcorex throws an error when the path is the empty string with the `LookupInOpTypeGet` op type)