### PR TITLE
Update gomod to indicate minimum go version of 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/stellar-gateway
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3


### PR DESCRIPTION
We use atomic.Pointer which is a 1.19 feature, so indicating 1.18 is incorrect.