### PR TITLE
Added repo-token to GHA protoc installation.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: 3.17
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: 3.17
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Tools
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28


### PR DESCRIPTION
This is needed as they do a GitHub fetch to identify version information for protoc and we get rate limited periodically.