### PR TITLE
ING-571: Update maximum receive message size to be 25MB

### DIFF
--- a/gateway/system/system.go
+++ b/gateway/system/system.go
@@ -34,6 +34,8 @@ import (
 
 // TODO(brett19): Implement the gateway system as its own component
 
+const maxMsgSize = 25000000 // 25MB
+
 type SystemOptions struct {
 	Logger *zap.Logger
 
@@ -78,6 +80,7 @@ func NewSystem(opts *SystemOptions) (*System, error) {
 			otelgrpc.StreamServerInterceptor(),
 		),
 		grpc.Creds(credentials.NewTLS(opts.TlsConfig)),
+		grpc.MaxRecvMsgSize(maxMsgSize),
 	}
 
 	dataSrv := grpc.NewServer(serverOpts...)


### PR DESCRIPTION
Motivation
----------
By default the maximum size that grpc will allow on the receive size is 4MB. Memcached will allow values of 20MB to created, so this 4MB is not big enough. We should increase the size to 25MB to allow a bit of leaway and also allow us to return meaningful error messages to the user, rather than the default grpc error.