### PR TITLE
ING-601: Update GetAllReplicas to exit if all requests errored

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1256,7 +1256,10 @@ func (s *KvServer) GetAllReplicas(in *kv_v1.GetAllReplicasRequest, out kv_v1.KvS
 		}()
 	}
 
-	for {
+	// Errors for the get requests are ignored unless they are in a specific set of errors.
+	// This means that we need to bail out when remainingReads is 0 - it's possible for all results
+	// to not write an error or a result into the result written to the channel.
+	for remainingReads > 0 {
 		firstRes := <-outCh
 		remainingReads--
 


### PR DESCRIPTION
Motivation
-----------
In GetAllReplicas if any of the get requests return an error which is not in a specific set of errors then we will ignore the error and write a result containing no data or error into the internal stream. When this happens we end up waiting on the results channel indefinitely. If all replicas + master have written to the channel but none have returned data or an error then we need to stop looping.

Changes
-------
Update GetAllReplicas to stop looping when we have read all results from the channel even if none had an error or data.