### PR TITLE
ING-591: Update bucket management replica indexes handling

### DIFF
--- a/gateway/dataimpl/server_v1/bucketadminserver.go
+++ b/gateway/dataimpl/server_v1/bucketadminserver.go
@@ -83,7 +83,7 @@ func (s *BucketAdminServer) ListBuckets(
 			FlushEnabled:           bucket.FlushEnabled,
 			RamQuotaMb:             bucket.RAMQuotaMB,
 			NumReplicas:            bucket.ReplicaNumber,
-			ReplicaIndexes:         !bucket.ReplicaIndexDisabled,
+			ReplicaIndexes:         bucket.ReplicaIndex,
 			BucketType:             bucketType,
 			EvictionMode:           evictionMode,
 			MaxExpirySecs:          uint32(bucket.MaxTTL / time.Second),
@@ -113,7 +113,11 @@ func (s *BucketAdminServer) CreateBucket(
 		flushEnabled = *in.FlushEnabled
 	}
 
-	replicaIndexes := false
+	var replicaIndexes bool
+	if in.BucketType == admin_bucket_v1.BucketType_BUCKET_TYPE_COUCHBASE {
+		// We default to true to match server behaviour.
+		replicaIndexes = true
+	}
 	if in.ReplicaIndexes != nil {
 		replicaIndexes = *in.ReplicaIndexes
 	}
@@ -202,7 +206,7 @@ func (s *BucketAdminServer) CreateBucket(
 				DurabilityMinLevel: minimumDurabilityLevel,
 			},
 			ConflictResolutionType: conflictResolutionType,
-			ReplicaIndexDisabled:   !replicaIndexes,
+			ReplicaIndex:           replicaIndexes,
 			BucketType:             bucketType,
 			StorageBackend:         storageBackend,
 		},

--- a/gateway/test/bucket_mgmt_test.go
+++ b/gateway/test/bucket_mgmt_test.go
@@ -1,0 +1,111 @@
+package test
+
+import (
+	"context"
+
+	"github.com/couchbase/goprotostellar/genproto/admin_bucket_v1"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func (s *GatewayOpsTestSuite) TestBucketManagement() {
+	if !s.SupportsFeature(TestFeatureBucketManagement) {
+		s.T().Skip()
+	}
+
+	adminClient := admin_bucket_v1.NewBucketAdminServiceClient(s.gatewayConn)
+
+	s.Run("CreateDefaults", func() {
+		name := uuid.NewString()[:6]
+		resp, err := adminClient.CreateBucket(context.Background(), &admin_bucket_v1.CreateBucketRequest{
+			BucketName: name,
+			BucketType: admin_bucket_v1.BucketType_BUCKET_TYPE_COUCHBASE,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), resp, err)
+
+		listResp, err := adminClient.ListBuckets(context.Background(), &admin_bucket_v1.ListBucketsRequest{},
+			grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), listResp, err)
+
+		var found *admin_bucket_v1.ListBucketsResponse_Bucket
+		for _, b := range listResp.Buckets {
+			if b.BucketName == name {
+				found = b
+				break
+			}
+		}
+		if assert.NotNil(s.T(), found, "Did not find bucket on cluster") {
+			assert.Equal(s.T(), admin_bucket_v1.BucketType_BUCKET_TYPE_COUCHBASE, found.BucketType)
+			assert.Equal(s.T(), uint64(100), found.RamQuotaMb)
+			assert.True(s.T(), found.ReplicaIndexes)
+		}
+
+		deleteResp, err := adminClient.DeleteBucket(context.Background(), &admin_bucket_v1.DeleteBucketRequest{
+			BucketName: name,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), deleteResp, err)
+	})
+
+	s.Run("CreateReplicaIndexDisabled", func() {
+		name := uuid.NewString()[:6]
+		replicaIndexes := false
+		resp, err := adminClient.CreateBucket(context.Background(), &admin_bucket_v1.CreateBucketRequest{
+			BucketName:     name,
+			BucketType:     admin_bucket_v1.BucketType_BUCKET_TYPE_COUCHBASE,
+			ReplicaIndexes: &replicaIndexes,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), resp, err)
+
+		listResp, err := adminClient.ListBuckets(context.Background(), &admin_bucket_v1.ListBucketsRequest{},
+			grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), resp, err)
+
+		var found *admin_bucket_v1.ListBucketsResponse_Bucket
+		for _, b := range listResp.Buckets {
+			if b.BucketName == name {
+				found = b
+				break
+			}
+		}
+		if assert.NotNil(s.T(), found, "Did not find bucket on cluster") {
+			assert.False(s.T(), found.ReplicaIndexes)
+		}
+
+		deleteResp, err := adminClient.DeleteBucket(context.Background(), &admin_bucket_v1.DeleteBucketRequest{
+			BucketName: name,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), deleteResp, err)
+	})
+
+	s.Run("CreateEphemeralDefaults", func() {
+		name := uuid.NewString()[:6]
+		resp, err := adminClient.CreateBucket(context.Background(), &admin_bucket_v1.CreateBucketRequest{
+			BucketName: name,
+			BucketType: admin_bucket_v1.BucketType_BUCKET_TYPE_EPHEMERAL,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), resp, err)
+
+		listResp, err := adminClient.ListBuckets(context.Background(), &admin_bucket_v1.ListBucketsRequest{},
+			grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), listResp, err)
+
+		var found *admin_bucket_v1.ListBucketsResponse_Bucket
+		for _, b := range listResp.Buckets {
+			if b.BucketName == name {
+				found = b
+				break
+			}
+		}
+		if assert.NotNil(s.T(), found, "Did not find bucket on cluster") {
+			assert.Equal(s.T(), admin_bucket_v1.BucketType_BUCKET_TYPE_EPHEMERAL, found.BucketType)
+			assert.Equal(s.T(), uint64(100), found.RamQuotaMb)
+			assert.False(s.T(), found.ReplicaIndexes)
+		}
+
+		deleteResp, err := adminClient.DeleteBucket(context.Background(), &admin_bucket_v1.DeleteBucketRequest{
+			BucketName: name,
+		}, grpc.PerRPCCredentials(s.basicRpcCreds))
+		requireRpcSuccess(s.T(), deleteResp, err)
+	})
+}

--- a/gateway/test/feature_test.go
+++ b/gateway/test/feature_test.go
@@ -11,6 +11,7 @@ var (
 	TestFeatureQueryManagement             = TestFeatureCode("querymgmt")
 	TestFeatureSearchManagement            = TestFeatureCode("searchmgmt")
 	TestFeatureSearchManagementCollections = TestFeatureCode("searchmgmtcollections")
+	TestFeatureBucketManagement            = TestFeatureCode("bucketmgmt")
 )
 
 type TestFeature struct {
@@ -46,6 +47,8 @@ func (s *GatewayOpsTestSuite) SupportsFeature(code TestFeatureCode) bool {
 	case TestFeatureSearch:
 		return true
 	case TestFeatureQuery:
+		return true
+	case TestFeatureBucketManagement:
 		return true
 	case TestFeatureQueryManagement:
 		return true


### PR DESCRIPTION
Motivation
----------
Creating ephemeral buckets currently requires users to explicitly set replica indexes to false. We should update our handling so that replica indexes defaults to false for ephemeral buckets and true for couchbase buckets.