### PR TITLE
ING-429: Added log handler for cbauth to consolidate logging.

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/couchbase/cbauth"
+	"github.com/couchbase/cbauth/revrpc"
 	"github.com/couchbase/gocbcorex"
 	"github.com/couchbase/stellar-gateway/contrib/cbconfig"
 	"github.com/couchbase/stellar-gateway/contrib/cbtopology"
@@ -186,6 +187,16 @@ func (g *Gateway) Run(ctx context.Context) error {
 	}
 
 	// initialize cb-auth
+	cbauthLogger := config.Logger.Named("cbauth")
+	revrpc.DefaultBabysitErrorPolicy = revrpc.DefaultErrorPolicy{
+		RestartsToExit:       -1,
+		SleepBetweenRestarts: time.Second,
+		LogPrint: func(v ...any) {
+			cbauthLogger.Info("cbauth message",
+				zap.String("message", fmt.Sprint(v...)))
+		},
+	}
+
 	err = cbauth.InitExternalWithHeartbeat("stg", mgmtHostPort, config.Username, config.Password, 5, 10)
 	if err != nil {
 		if strings.Contains(err.Error(), "already initialized") {


### PR DESCRIPTION
Previously cbauth would log to stdout directly rather than using our integrated zap logging.  This commit configures a custom handler for cbauth that forwards all its logging through zap.