### PR TITLE
ING-453 Return docExistsStatus when ErrNotFound

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1283,6 +1283,8 @@ func (s *KvServer) MutateIn(ctx context.Context, in *kv_v1.MutateInRequest) (*kv
 			return nil, s.errorHandler.NewValueTooLargeStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key, true).Err()
 		} else if errors.Is(err, memdx.ErrSubDocInvalidCombo) {
 			return nil, s.errorHandler.NewSdBadCombo(err).Err()
+		} else if errors.Is(err, memdx.ErrDocNotStored) {
+			return nil, s.errorHandler.NewDocExistsStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key).Err()
 		} else {
 			var subdocErr *memdx.SubDocError
 			if errors.As(err, &subdocErr) {


### PR DESCRIPTION
MutateIn with Insert Semantics can occasionally return status NotFound instead of AlreadyExists when we attempt to insert an existing document. This status is now handled in `gocbcorex` and a custom error returned. This PR allows STG to handle that error and returns the expected DocExists status.