### PR TITLE
ING-625 Return useful error when mutateIn insert doc exists

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1283,6 +1283,8 @@ func (s *KvServer) MutateIn(ctx context.Context, in *kv_v1.MutateInRequest) (*kv
 			return nil, s.errorHandler.NewValueTooLargeStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key, true).Err()
 		} else if errors.Is(err, memdx.ErrSubDocInvalidCombo) {
 			return nil, s.errorHandler.NewSdBadCombo(err).Err()
+		} else if errors.Is(err, memdx.ErrDocExists) {
+			return nil, s.errorHandler.NewDocExistsStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key).Err()
 		} else {
 			var subdocErr *memdx.SubDocError
 			if errors.As(err, &subdocErr) {


### PR DESCRIPTION
Currently if we attempt to perform a MutateIn subdoc operation with insert semantics when the document already exists we get an internal server error. Gocbcorex already returns a document exists err so we should handle this and return a useful error to the user. The error now returned is:
```
panic: document exists | {"context":{"details":1,"resource_name":"default/_default/_default/customer123","
resource_type":"document","server":"Document 'customer123' already existed in 'default/_default/_default'."}}
```