### PR TITLE
ING-624 Return useful status on SyncWrite error

### DIFF
--- a/gateway/dataimpl/server_v1/errorhandler.go
+++ b/gateway/dataimpl/server_v1/errorhandler.go
@@ -594,3 +594,16 @@ func (e ErrorHandler) NewKeyTooLongStatus(key string) *status.Status {
 	st := status.New(codes.InvalidArgument, fmt.Sprintf("Document key '%s' is too long", key))
 	return st
 }
+
+func (e ErrorHandler) NewSyncWriteInProgressStatus(baseErr error, bucketName, scopeName, collectionName, docId string) *status.Status {
+	st := status.New(codes.Aborted,
+		fmt.Sprintf("Document '%s' in '%s/%s/%s' is being concurrently written.",
+			docId, bucketName, scopeName, collectionName))
+	st = e.tryAttachStatusDetails(st, &epb.ResourceInfo{
+		ResourceType: "document",
+		ResourceName: fmt.Sprintf("%s/%s/%s/%s", bucketName, scopeName, collectionName, docId),
+		Description:  "",
+	})
+	st = e.tryAttachExtraContext(st, baseErr)
+	return st
+}

--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1283,6 +1283,8 @@ func (s *KvServer) MutateIn(ctx context.Context, in *kv_v1.MutateInRequest) (*kv
 			return nil, s.errorHandler.NewValueTooLargeStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key, true).Err()
 		} else if errors.Is(err, memdx.ErrSubDocInvalidCombo) {
 			return nil, s.errorHandler.NewSdBadCombo(err).Err()
+		} else if errors.Is(err, memdx.ErrSyncWriteInProgress) {
+			return nil, s.errorHandler.NewSyncWriteInProgressStatus(err, in.BucketName, in.ScopeName, in.CollectionName, in.Key).Err()
 		} else {
 			var subdocErr *memdx.SubDocError
 			if errors.As(err, &subdocErr) {


### PR DESCRIPTION
Currently concurrent mutate in operations with insert semantics results in an internal server error being returned to the User. Now that gocbcorex returns a custom error in this case we can handle it and return the following, informative error to the SDK user: 
```
panic: internal server failure | {"context":{"details":1,"resource_name":"default/_default/_default/customer123",
"resource_type":"document","server":"Document 'customer123' in 'default/_default/_default' is being concurrently written."}}
```