### PR TITLE
ING-610: Ensure collection management is self-consistent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/couchbase/cbauth v0.1.11-0.20230814221519-3b2c4d828dda
 	github.com/couchbase/gocb/v2 v2.6.5
 	github.com/couchbase/gocbcore/v10 v10.2.9
-	github.com/couchbase/gocbcorex v0.0.0-20231128095332-a6524e15a407
+	github.com/couchbase/gocbcorex v0.0.0-20231128101734-4a90666dcd14
 	github.com/couchbase/goprotostellar v1.0.1-0.20231122171617-af784dfc3d53
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/couchbase/gocb/v2 v2.6.5 h1:xaZu29o8UJEV1ZQ3n2s9jcRCUHz/JsQ6+y6JBnVsy
 github.com/couchbase/gocb/v2 v2.6.5/go.mod h1:0vFM09y+VPhnXeNrIb8tS0wKHGpJvjJBrJnriWEiwGs=
 github.com/couchbase/gocbcore/v10 v10.2.9 h1:zph/+ceu3JtZEDKhJMTRc6lGrahq+mnlQY/1dSepJuE=
 github.com/couchbase/gocbcore/v10 v10.2.9/go.mod h1:lYQIIk+tzoMcwtwU5GzPbDdqEkwkH3isI2rkSpfL0oM=
-github.com/couchbase/gocbcorex v0.0.0-20231128095332-a6524e15a407 h1:kNnUyWswVMaBzlyjS7UsaDTy5xlucYWxEQHDw+1EWkU=
-github.com/couchbase/gocbcorex v0.0.0-20231128095332-a6524e15a407/go.mod h1:On+ek6dOXrkBUybNdAlM4M37OcFoDmT6taRrQ+2vgA8=
+github.com/couchbase/gocbcorex v0.0.0-20231128101734-4a90666dcd14 h1:192o7UmuoOEQhsqr2XF2zSKR9uQVJVlx3o4lUUKQh8M=
+github.com/couchbase/gocbcorex v0.0.0-20231128101734-4a90666dcd14/go.mod h1:On+ek6dOXrkBUybNdAlM4M37OcFoDmT6taRrQ+2vgA8=
 github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUlhv9I2U=
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goprotostellar v1.0.1-0.20231122171617-af784dfc3d53 h1:Th9tnzpnPHqkz18jhQNG/jpmNIIji83oDRuqQgjY+xM=


### PR DESCRIPTION
Currently if we create/drop a collection then attempt to immediately use it we can encounter errors. For example in the following validations we create a collection named "newCollection" then immediately list collections, and sometimes it will be missing. The inverse can occur when dropped:

# Before fix
If we run the test a few times we will eventually see that when listing collections after creation we cannot see "newCollection" whereas after we drop "newCollection" the cluster still thinks it exists.
```
SCOPES AND COLLECTIONS AFTER CREATION:
[{_default [{_default _default 0s <nil>}]}]

SCOPES AND COLLECTIONS AFTER DROPPING:
[{_default [{newCollection _default 0s <nil>} {_default _default 0s <nil>}]}]
```

# After fix
The result is always as follows which is the correct behaviour. 
```
SCOPES AND COLLECTIONS AFTER CREATION:
[{_default [{newCollection _default 0s <nil>} {_default _default 0s <nil>}]}]

SCOPES AND COLLECTIONS AFTER DROPPING:
[{_default [{_default _default 0s <nil>}]}]
```
