### PR TITLE
ING-650: Return fully qualififed index names from query index errs

### DIFF
--- a/gateway/dataimpl/server_v1/errorhandler.go
+++ b/gateway/dataimpl/server_v1/errorhandler.go
@@ -224,13 +224,23 @@ func (e ErrorHandler) NewCollectionExistsStatus(baseErr error, bucketName, scope
 	return st
 }
 
-func (e ErrorHandler) NewQueryIndexMissingStatus(baseErr error, indexName string) *status.Status {
+func (e ErrorHandler) NewQueryIndexMissingStatus(baseErr error, indexName, bucketName, scopeName, collectionName string) *status.Status {
+	var path string
+	if bucketName != "" {
+		path = bucketName
+		if scopeName != "" {
+			path = path + "/" + scopeName
+			if collectionName != "" {
+				path = path + "/" + collectionName
+			}
+		}
+	}
+
 	var msg string
 	if indexName == "" {
 		msg = "Query index not found."
 	} else {
-		msg = fmt.Sprintf("Query index '%s' not found.",
-			indexName)
+		msg = fmt.Sprintf("Query index '%s' not found in '%s'.", indexName, path)
 	}
 	st := status.New(codes.NotFound, msg)
 	st = e.tryAttachStatusDetails(st, &epb.ResourceInfo{
@@ -242,13 +252,23 @@ func (e ErrorHandler) NewQueryIndexMissingStatus(baseErr error, indexName string
 	return st
 }
 
-func (e ErrorHandler) NewQueryIndexExistsStatus(baseErr error, indexName string) *status.Status {
+func (e ErrorHandler) NewQueryIndexExistsStatus(baseErr error, indexName, bucketName, scopeName, collectionName string) *status.Status {
+	var path string
+	if bucketName != "" {
+		path = bucketName
+		if scopeName != "" {
+			path = path + "/" + scopeName
+			if collectionName != "" {
+				path = path + "/" + collectionName
+			}
+		}
+	}
+
 	var msg string
 	if indexName == "" {
 		msg = "Query index already existed."
 	} else {
-		msg = fmt.Sprintf("Query index '%s' already existed.",
-			indexName)
+		msg = fmt.Sprintf("Query index '%s' already existed in  '%s'.", indexName, path)
 	}
 	st := status.New(codes.AlreadyExists, msg)
 	st = e.tryAttachStatusDetails(st, &epb.ResourceInfo{
@@ -275,18 +295,25 @@ func (e ErrorHandler) NewQueryIndexNotBuildingStatus(baseErr error, bucketName, 
 	return st
 }
 
-func (e ErrorHandler) NewQueryIndexAuthenticationFailureStatus(baseErr error, indexName string) *status.Status {
-	st := status.New(codes.PermissionDenied, "Insufficient permissions to perform query index operation.")
-	st = e.tryAttachStatusDetails(st, &epb.ResourceInfo{
-		ResourceType: "queryindex",
-		ResourceName: indexName,
-		Description:  "",
-	})
+func (e ErrorHandler) NewQueryIndexAuthenticationFailureStatus(baseErr error, bucketName, scopeName, collectionName string) *status.Status {
+	var path string
+	if bucketName != "" {
+		path = bucketName
+		if scopeName != "" {
+			path = path + "/" + scopeName
+			if collectionName != "" {
+				path = path + "/" + collectionName
+			}
+		}
+	}
+
+	msg := fmt.Sprintf("Insufficient permissions to perform query index operation against %s.", path)
+	st := status.New(codes.PermissionDenied, msg)
 	st = e.tryAttachExtraContext(st, baseErr)
 	return st
 }
 
-func (e ErrorHandler) NewQueryIndexInvalidArgumentStatus(baseErr error, indexName string, msg string) *status.Status {
+func (e ErrorHandler) NewQueryIndexInvalidArgumentStatus(baseErr error, indexName, msg string) *status.Status {
 	st := status.New(codes.InvalidArgument, msg)
 	st = e.tryAttachStatusDetails(st, &epb.ResourceInfo{
 		ResourceType: "queryindex",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/couchbase/cbauth v0.1.2-0.20231201233522-321fd8cd46a0
 	github.com/couchbase/gocb/v2 v2.6.5
 	github.com/couchbase/gocbcore/v10 v10.2.9
-	github.com/couchbase/gocbcorex v0.0.0-20231206203128-e96676694c63
+	github.com/couchbase/gocbcorex v0.0.0-20231207001327-3e3cee82f99c
 	github.com/couchbase/goprotostellar v1.0.1-0.20231122171617-af784dfc3d53
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/couchbase/gocb/v2 v2.6.5 h1:xaZu29o8UJEV1ZQ3n2s9jcRCUHz/JsQ6+y6JBnVsy
 github.com/couchbase/gocb/v2 v2.6.5/go.mod h1:0vFM09y+VPhnXeNrIb8tS0wKHGpJvjJBrJnriWEiwGs=
 github.com/couchbase/gocbcore/v10 v10.2.9 h1:zph/+ceu3JtZEDKhJMTRc6lGrahq+mnlQY/1dSepJuE=
 github.com/couchbase/gocbcore/v10 v10.2.9/go.mod h1:lYQIIk+tzoMcwtwU5GzPbDdqEkwkH3isI2rkSpfL0oM=
-github.com/couchbase/gocbcorex v0.0.0-20231206203128-e96676694c63 h1:oVjvjyxb0ateRItjy08N5zPB6lCoRTOPedoa83kH/Ik=
-github.com/couchbase/gocbcorex v0.0.0-20231206203128-e96676694c63/go.mod h1:On+ek6dOXrkBUybNdAlM4M37OcFoDmT6taRrQ+2vgA8=
+github.com/couchbase/gocbcorex v0.0.0-20231207001327-3e3cee82f99c h1:ZY6UKf2hHhyWzdgnlgXUzMfu3bAQwYq97sNwQpHVuc8=
+github.com/couchbase/gocbcorex v0.0.0-20231207001327-3e3cee82f99c/go.mod h1:On+ek6dOXrkBUybNdAlM4M37OcFoDmT6taRrQ+2vgA8=
 github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUlhv9I2U=
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goprotostellar v1.0.1-0.20231122171617-af784dfc3d53 h1:Th9tnzpnPHqkz18jhQNG/jpmNIIji83oDRuqQgjY+xM=


### PR DESCRIPTION
Error messages will now be as follows. The IndexNotFound and IndexExists errors still do not contain the fully qualified path as gocbcorex does not know the paths when it gets the error from the server: 

# Index Not Found
```
panic: index not found | {"context":{"details":1,"resource_name":"missingIndex","resource_type":
"queryindex","server":"Query index 'missingIndex' not found."}}
```

# Index Exists
```
panic: index exists | {"context":{"details":1,"resource_name":"testingIndexTwoPointOh",
"resource_type":"queryindex","server":"Query index 'testingIndexTwoPointOh' already existed."}}
```

# Invalid Argument
```
panic: invalid argument | {"context":{"details":1,"resource_name":"test.testing.bucket/testScope/
testCol:tooManyReplicas","resource_type":"queryindex","server":"invalid argument: NumReplicas 
- not enough indexer nodes to create index with replica count"}}
```

# Auth Error
```
panic: server reported that permission to the resource was denied: authentication failure - possible 
reasons - incorrect authentication configuration, bucket doesn’t exist or bucket may be hibernated 
| {"context":{"details":0,"server":"Insufficient permissions to perform query index operation 
against test.testing.bucket/testScope/testCol."}}
```