### PR TITLE
ING-523: Improved GetAllReplicas handling

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1394,155 +1394,42 @@ func (s *KvServer) GetAllReplicas(in *kv_v1.GetAllReplicasRequest, out kv_v1.KvS
 		return errSt.Err()
 	}
 
-	getFromMaster := func() (*kv_v1.GetAllReplicasResponse, *status.Status) {
-		var opts gocbcorex.GetOptions
-		opts.OnBehalfOf = oboUser
-		opts.ScopeName = in.ScopeName
-		opts.CollectionName = in.CollectionName
-		opts.Key = []byte(in.Key)
+	var opts gocbcorex.GetAllReplicasOptions
+	opts.OnBehalfOf = oboUser
+	opts.ScopeName = in.ScopeName
+	opts.CollectionName = in.CollectionName
+	opts.Key = []byte(in.Key)
+	opts.BucketName = in.BucketName
+	replicaStream, err := bucketAgent.GetAllReplicas(out.Context(), &opts)
+	if err != nil {
+		if errors.Is(err, memdx.ErrUnknownCollectionName) {
+			return s.errorHandler.NewCollectionMissingStatus(err, in.BucketName, in.ScopeName, in.CollectionName).Err()
+		} else if errors.Is(err, memdx.ErrUnknownScopeName) {
+			return s.errorHandler.NewScopeMissingStatus(err, in.BucketName, in.ScopeName).Err()
+		} else if errors.Is(err, memdx.ErrAccessError) {
+			return s.errorHandler.NewCollectionNoReadAccessStatus(err, in.BucketName, in.ScopeName, in.CollectionName).Err()
+		} else {
+			return s.errorHandler.NewGenericStatus(err).Err()
+		}
+	}
 
-		result, err := bucketAgent.Get(out.Context(), &opts)
+	res, err := replicaStream.Next()
+	for res != nil {
+		err = out.Send(&kv_v1.GetAllReplicasResponse{
+			IsReplica:    res.IsReplica,
+			Content:      res.Value,
+			ContentFlags: res.Flags,
+			Cas:          res.Cas})
 		if err != nil {
-			if errors.Is(err, memdx.ErrUnknownCollectionName) {
-				return nil, s.errorHandler.NewCollectionMissingStatus(err, in.BucketName, in.ScopeName, in.CollectionName)
-			} else if errors.Is(err, memdx.ErrUnknownScopeName) {
-				return nil, s.errorHandler.NewScopeMissingStatus(err, in.BucketName, in.ScopeName)
-			} else if errors.Is(err, memdx.ErrAccessError) {
-				return nil, s.errorHandler.NewCollectionNoReadAccessStatus(err, in.BucketName, in.ScopeName, in.CollectionName)
-			}
-
-			s.logger.Debug("GetAllReplicas GetFromMaster failed but is being ignored",
-				zap.Error(err))
-			return nil, nil
+			return err
 		}
 
-		return &kv_v1.GetAllReplicasResponse{
-			IsReplica:    false,
-			Content:      result.Value,
-			ContentFlags: result.Flags,
-			Cas:          result.Cas,
-		}, nil
+		res, err = replicaStream.Next()
 	}
 
-	getFromReplica := func(replicaIdx uint32) (*kv_v1.GetAllReplicasResponse, *status.Status) {
-		var opts gocbcorex.GetReplicaOptions
-		opts.OnBehalfOf = oboUser
-		opts.ScopeName = in.ScopeName
-		opts.CollectionName = in.CollectionName
-		opts.Key = []byte(in.Key)
-		opts.ReplicaIdx = replicaIdx
-
-		result, err := bucketAgent.GetReplica(out.Context(), &opts)
-		if err != nil {
-			if errors.Is(err, memdx.ErrUnknownCollectionName) {
-				return nil, s.errorHandler.NewCollectionMissingStatus(err, in.BucketName, in.ScopeName, in.CollectionName)
-			} else if errors.Is(err, memdx.ErrUnknownScopeName) {
-				return nil, s.errorHandler.NewScopeMissingStatus(err, in.BucketName, in.ScopeName)
-			} else if errors.Is(err, memdx.ErrAccessError) {
-				return nil, s.errorHandler.NewCollectionNoReadAccessStatus(err, in.BucketName, in.ScopeName, in.CollectionName)
-			}
-
-			s.logger.Debug("GetAllReplicas GetFromReplica failed but is being ignored",
-				zap.Uint32("replicaIdx", replicaIdx),
-				zap.Error(err))
-			return nil, nil
-		}
-
-		return &kv_v1.GetAllReplicasResponse{
-			IsReplica:    true,
-			Content:      result.Value,
-			ContentFlags: result.Flags,
-			Cas:          result.Cas,
-		}, nil
+	if err != nil {
+		s.logger.Debug("error reading a replica", zap.Error(err))
 	}
-
-	// our current implementation of GetAllReplicas is somewhat less optimal compared
-	// to what should be possible with full gocbcorex support for this.  primarily, we
-	// execute a replica read on all _possible_ replicas, even if we don't have that
-	// many replicas configured.  Any replicas which are not accessible will return
-	// an ErrInvalidReplicaIdx error, and since all errors are ignored by GetReplicas,
-	// we will simply ignore sending that particular value.
-
-	maxReplicaScans := uint32(3)
-
-	type result struct {
-		res   *kv_v1.GetAllReplicasResponse
-		errSt *status.Status
-	}
-	outCh := make(chan result, maxReplicaScans+1)
-
-	go func() {
-		res, errSt := getFromMaster()
-		outCh <- result{
-			res:   res,
-			errSt: errSt,
-		}
-	}()
-	for replicaIdx := uint32(0); replicaIdx < maxReplicaScans; replicaIdx++ {
-		go func(replicaIdx uint32) {
-			res, errSt := getFromReplica(replicaIdx)
-			outCh <- result{
-				res:   res,
-				errSt: errSt,
-			}
-		}(replicaIdx)
-	}
-
-	remainingReads := 1 + maxReplicaScans
-	asyncReadRemaining := func() {
-		go func() {
-			for remainingReads > 0 {
-				<-outCh
-				remainingReads--
-			}
-			close(outCh)
-		}()
-	}
-
-	// Errors for the get requests are ignored unless they are in a specific set of errors.
-	// This means that we need to bail out when remainingReads is 0 - it's possible for all results
-	// to not write an error or a result into the result written to the channel.
-	for remainingReads > 0 {
-		firstRes := <-outCh
-		remainingReads--
-
-		if firstRes.errSt != nil {
-			// if the first result had some sort of error, we start a goroutine to clean
-			// up the remaining results, and immediately return the generated error.
-
-			asyncReadRemaining()
-			return firstRes.errSt.Err()
-		}
-
-		if firstRes.res != nil {
-			// If we actually got a proper result from this response, we send it and then
-			// break to the remaining handling below, otherwise we fetch the next result.
-			err := out.Send(firstRes.res)
-			if err != nil {
-				asyncReadRemaining()
-				return s.errorHandler.NewGenericStatus(err).Err()
-			}
-
-			break
-		}
-	}
-
-	// once the first read has been successful, we no longer accept errors and simply
-	// pretend like they did not occur
-	for remainingReads > 0 {
-		nextRes := <-outCh
-		remainingReads--
-
-		if nextRes.res != nil {
-			err := out.Send(nextRes.res)
-			if err != nil {
-				asyncReadRemaining()
-				return s.errorHandler.NewGenericStatus(err).Err()
-			}
-		}
-	}
-
-	close(outCh)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/couchbase/cbauth v0.1.2-0.20231214203958-0685e2541e67
 	github.com/couchbase/gocb/v2 v2.6.5
 	github.com/couchbase/gocbcore/v10 v10.2.9
-	github.com/couchbase/gocbcorex v0.0.0-20240417221630-a85931916090
+	github.com/couchbase/gocbcorex v0.0.0-20240424073013-df7f35f42b41
 	github.com/couchbase/goprotostellar v1.0.2-0.20240202223538-0bb16b9c3422
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/fsnotify/fsnotify v1.7.0
@@ -77,6 +77,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/couchbase/gocb/v2 v2.6.5 h1:xaZu29o8UJEV1ZQ3n2s9jcRCUHz/JsQ6+y6JBnVsy
 github.com/couchbase/gocb/v2 v2.6.5/go.mod h1:0vFM09y+VPhnXeNrIb8tS0wKHGpJvjJBrJnriWEiwGs=
 github.com/couchbase/gocbcore/v10 v10.2.9 h1:zph/+ceu3JtZEDKhJMTRc6lGrahq+mnlQY/1dSepJuE=
 github.com/couchbase/gocbcore/v10 v10.2.9/go.mod h1:lYQIIk+tzoMcwtwU5GzPbDdqEkwkH3isI2rkSpfL0oM=
-github.com/couchbase/gocbcorex v0.0.0-20240417221630-a85931916090 h1:fRkNoWCIZ+icXtA2YWvqKbeXioGxmlBVKa3f4nXo6hs=
-github.com/couchbase/gocbcorex v0.0.0-20240417221630-a85931916090/go.mod h1:v9CmSqiC/KRx2S5/6Hr4o2KwM57Y5aEohBl2TqF1P5c=
+github.com/couchbase/gocbcorex v0.0.0-20240424073013-df7f35f42b41 h1:yQcQzDuj77CmB06qdSb4euv0xWt5qXHDz2xzq0hYK6Q=
+github.com/couchbase/gocbcorex v0.0.0-20240424073013-df7f35f42b41/go.mod h1:xVITc0ZPW6odCmp6cEfiPjwC2DdsR44dbaAxSCQAEnc=
 github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUlhv9I2U=
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goprotostellar v1.0.2-0.20240202223538-0bb16b9c3422 h1:YD7VGPnolkgxrQiUhpiXCHSsBXuNzq6/RyNckZpXGdU=
@@ -248,6 +248,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -298,6 +299,8 @@ go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=


### PR DESCRIPTION
Although the GetAllReplicas change in gocbcorex means that individual replica reads can push an error to the channel this hasn't been propagated to STG, since doing so would cause a change in behaviour between traditional GetAllReplicas 
and GetAllReplicas through protostellar.  I think this would be a nice change in future, but if we do so we should update all GetAllReplicas, so for the time being STG will behave the same as core GetAllReplicas and just log any individual replica read errors. 