### PR TITLE
ING-779: Reject unknown fields in requests to the server.

### DIFF
--- a/contrib/grpcrejectunknown/grpcrejectunknown.go
+++ b/contrib/grpcrejectunknown/grpcrejectunknown.go
@@ -1,0 +1,27 @@
+package grpcrejectunknown
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func MakeGrpcUnaryInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		reqMsg := req.(proto.Message)
+
+		unkFields := reqMsg.ProtoReflect().GetUnknown()
+		if len(unkFields) > 0 {
+			logger.Debug("rejecting request due to unexpected fields present in request",
+				zap.ByteString("fields", unkFields))
+
+			return nil, status.New(codes.Unimplemented, "An unimplemented field was encountered.").Err()
+		}
+
+		return handler(ctx, req)
+	}
+}

--- a/gateway/system/system.go
+++ b/gateway/system/system.go
@@ -24,6 +24,7 @@ import (
 	"github.com/couchbase/goprotostellar/genproto/routing_v1"
 	"github.com/couchbase/goprotostellar/genproto/search_v1"
 	"github.com/couchbase/goprotostellar/genproto/transactions_v1"
+	"github.com/couchbase/stellar-gateway/contrib/grpcrejectunknown"
 	"github.com/couchbase/stellar-gateway/gateway/dataimpl"
 	"github.com/couchbase/stellar-gateway/gateway/hooks"
 	"github.com/couchbase/stellar-gateway/gateway/sdimpl"
@@ -70,6 +71,8 @@ func NewSystem(opts *SystemOptions) (*System, error) {
 	var unaryInterceptors []grpc.UnaryServerInterceptor
 	unaryInterceptors = append(unaryInterceptors, otelgrpc.UnaryServerInterceptor())
 	unaryInterceptors = append(unaryInterceptors, metricsInterceptor.UnaryInterceptor())
+	unaryInterceptors = append(unaryInterceptors,
+		grpcrejectunknown.MakeGrpcUnaryInterceptor(opts.Logger))
 	if opts.Debug {
 		unaryInterceptors = append(unaryInterceptors, debugInterceptor.UnaryInterceptor())
 	}

--- a/gateway/test/badfield_test.go
+++ b/gateway/test/badfield_test.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"context"
+
+	"github.com/couchbase/goprotostellar/genproto/kv_v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func (s *GatewayOpsTestSuite) TestUnknownFields() {
+	kvClient := kv_v1.NewKvServiceClient(s.gatewayConn)
+
+	s.Run("RejectUnknown", func() {
+		req := &kv_v1.GetRequest{
+			BucketName:     s.bucketName,
+			ScopeName:      s.scopeName,
+			CollectionName: s.collectionName,
+			Key:            s.testDocId(),
+		}
+
+		// craft some unknown fields into the message
+		var unkFields []byte
+		unkFields = protowire.AppendTag(unkFields, 0xFFFF, protowire.VarintType)
+		unkFields = protowire.AppendVarint(unkFields, 0xFF)
+		req.ProtoReflect().SetUnknown(unkFields)
+
+		_, err := kvClient.Get(context.Background(), req, grpc.PerRPCCredentials(s.basicRpcCreds))
+		assertRpcStatus(s.T(), err, codes.Unimplemented)
+	})
+}


### PR DESCRIPTION
I've pushed this potential change, but I'm still a bit dubious if it's the correct solution for handling cross-version issues like the one described in ING-779.