### PR TITLE
ING-1014: Initialise strict server options as non-nil

### DIFF
--- a/gateway/system/system.go
+++ b/gateway/system/system.go
@@ -154,7 +154,16 @@ func NewSystem(opts *SystemOptions) (*System, error) {
 		dapiimpl.NewOtelTracingHandler(),
 		dapiimpl.NewUserAgentMetricsHandler(),
 		oapimetrics.NewStatsHandler(opts.Logger),
-	}, dataapiv1.StrictHTTPServerOptions{})
+	}, dataapiv1.StrictHTTPServerOptions{
+		// TODO: have a way to propagate the error that is passed to these functions that avoids leaking
+		// information about the internals of the system
+		RequestErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, "", http.StatusInternalServerError)
+		},
+		ResponseErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, "", http.StatusInternalServerError)
+		},
+	})
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/", dataapiv1.Handler(sh))


### PR DESCRIPTION
When an error occurs in the Data API strict handler before reaching the application code (e.g an error unmarshaling the request body) the generated go code calls `strictHandler.options.ResponseErrorHandler()`. Currently when we initialise the strict handler we do not initialise the strict handler options, so this call panics as shown in ING-1014 as the options are nil. This PR initialises the strict handler options to avoid this panic. 

When repeating the same test as on the ING ticket we now get: 

```
< HTTP/2 400
< content-type: text/plain; charset=utf-8
< vary: Origin
< x-content-type-options: nosniff
< content-length: 132
< date: Mon, 24 Feb 2025 14:20:06 GMT
<
can't decode JSON body: json: cannot unmarshal number -100 into Go struct field LockDocumentJSONRequestBody.lockTime of type uint32
* Connection #0 to host localhost left intact
```