### PR TITLE
ING-911: Add examples to data API request/response specs

### DIFF
--- a/dataapiv1/spec.yaml
+++ b/dataapiv1/spec.yaml
@@ -801,7 +801,7 @@ components:
         - DurabilityLevelNone
         - DurabilityLevelMajority
         - DurabilityLevelMajorityAndPersistOnMaster
-        - DurabilityLevelPersitToMajority
+        - DurabilityLevelPersistToMajority
     SubdocErrorCode:
       title: SubdocErrorCode
       description: SubdocErrorCode specifies the more specified error that occurred in a sub-document operation.

--- a/dataapiv1/spec.yaml
+++ b/dataapiv1/spec.yaml
@@ -21,6 +21,7 @@ paths:
                   user:
                     type: string
                     description: The user that is making the request.
+                    example: Administrator
         '403':
           $ref: '#/components/responses/Forbidden' 
         '500':
@@ -61,10 +62,17 @@ paths:
             X-CB-Flags:
               $ref: "#/components/headers/DocumentFlags"
           content:
+            'application/json':
+              schema:
+                type: object
+                description: The contents of the document.
+                example: { "hello": "world", "success": true}
             '*':
               schema:
                 type: string
                 format: binary
+                description: The contents of the document.
+                example: "Here is the contents of your document"
         '400':
           $ref: '#/components/responses/BadRequest' 
         '403':
@@ -93,6 +101,7 @@ paths:
             schema:
               type: string
               format: binary
+              description: The contents of the document.
       responses:
         '200':
           description: Successful creation of the document
@@ -131,7 +140,10 @@ paths:
         required: true
         content:
           '*':
-            schema: {}
+            schema:
+              type: string
+              format: binary
+              description: The contents of the document.
       responses:
         '200':
           description: Successful creation of the document
@@ -188,6 +200,8 @@ paths:
   '/v1.alpha/enabled':
     get:
       operationId: alphaEnabled
+      tags:
+        - Tools
       responses:
         '200':
           description: The alpha API is enabled
@@ -214,7 +228,7 @@ paths:
             schema: {}
       responses:
         '200':
-          description: Successful appended contents to the document.
+          description: Successfully appended contents to the document.
           headers:
             ETag:
               $ref: "#/components/headers/ETag"
@@ -255,7 +269,7 @@ paths:
             schema: {}
       responses:
         '200':
-          description: Successful prepended contents to the document.
+          description: Successfully prepended contents to the document.
           headers:
             ETag:
               $ref: "#/components/headers/ETag"
@@ -291,8 +305,6 @@ paths:
         - $ref: '#/components/parameters/DurabilityLevelHeader'
       requestBody:
         content:
-          '*':
-            schema: {}
           'application/json':
             schema:
               type: object
@@ -301,13 +313,17 @@ paths:
                   description: The value to set the document to if the document does not exist.
                   type: integer
                   format: uint64
+                  example: 10
                 delta:
                   description: The value to increment the document by if it exists.
                   type: integer
                   format: uint64
+                  example: 1
+          '*':
+            schema: {}
       responses:
         '200':
-          description: Successful incremented the document.
+          description: Successfully incremented the document.
           headers:
             ETag:
               $ref: "#/components/headers/ETag"
@@ -318,6 +334,8 @@ paths:
               schema:
                 type: integer
                 format: uint64
+                example: 10
+                description: The number stored in the document after incrementing/initializing.
         '400':
           $ref: '#/components/responses/BadRequest' 
         '403':
@@ -346,8 +364,6 @@ paths:
         - $ref: '#/components/parameters/DurabilityLevelHeader'
       requestBody:
         content:
-          '':
-            schema: {}
           'application/json':
             schema:
               type: object
@@ -356,13 +372,17 @@ paths:
                   type: integer
                   format: uint64
                   description: The value to set the document to if the document does not exist.
+                  example: 10
                 delta:
                   type: integer
                   format: uint64
-                  description: The value to increment the document by if it exists.
+                  description: The value to decrement the document by if it exists.
+                  example: 1
+          '*':
+            schema: {}
       responses:
         '200':
-          description: Successful incremented the document.
+          description: Successfully incremented the document.
           headers:
             ETag:
               $ref: "#/components/headers/ETag"
@@ -373,6 +393,8 @@ paths:
               schema:
                 type: integer
                 format: uint64
+                example: 11
+                description: The number stored in the document after decrementing/initializing.
         '400':
           $ref: '#/components/responses/BadRequest' 
         '403':
@@ -401,7 +423,7 @@ paths:
       requestBody:
         required: true
         content:
-         'application/json':
+          'application/json':
             schema:
               type: object
               properties:
@@ -409,9 +431,10 @@ paths:
                   description: The maximum period of time the document should remain locked.
                   type: integer
                   format: uint32
+                  example: 10
       responses:
         '200':
-          description: Successful locked the document
+          description: Successfully locked the document
           headers:
             Content-Encoding:
               $ref: "#/components/headers/ContentEncoding"
@@ -424,6 +447,7 @@ paths:
               schema:
                 type: string
                 format: binary
+                description: The contents of the document.
         '400':
           $ref: '#/components/responses/BadRequest' 
         '403':
@@ -448,12 +472,12 @@ paths:
     post:
       operationId: unlockDocument
       tags:
-        - Binary Operations
+        - Locking Operations
       parameters:
         - $ref: '#/components/parameters/IfMatchHeader'
       responses:
         '200':
-          description: Successful unlocked the document.
+          description: Successfully unlocked the document.
           headers:
             X-CB-MutationToken:
               $ref: "#/components/headers/MutationToken"
@@ -487,13 +511,14 @@ paths:
       requestBody:
         required: true
         content:
-         'application/json':
+          'application/json':
             schema:
               type: object
               properties:
                 expiry:
                   description: The new expiry to set for the document, specified as an ISO8601 string.
                   type: string
+                  example: "YYYY-MM-DDTHH:MM:SS.sssZ"
                 returnContent:
                   description: Specifies whether the documents contents should be returned in the response.
                   type: boolean
@@ -512,6 +537,7 @@ paths:
               schema:
                 type: string
                 format: binary
+                description: The contents of the document.
         '202':
           description: Successful updated the expiry of the document but is not returning the content of the document.
           headers:
@@ -639,48 +665,88 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            BadRequest:
+              value:
+                code: InvalidArgument
+                message: The request was malformed or invalid.
     Forbidden: # 403
       description: The user does not have permission to access the resource
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            Forbidden:
+              value:
+                code: InvalidAuth
+                message: Your username or password is invalid.
     NotFound: # 404
       description: The specified resource was not found
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            NotFound:
+              value:
+                code: ResourceNotFound
+                message: The requested resource was not found.
     Conflict: # 409
       description: A conflict occurred while processing the request
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            Conflict:
+              value:
+                code: ResourceConflict
+                message: There is a conflict with the current state of a resource.
     ContentTooLarge: # 413
       description: The document is too large to be stored
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            ContentTooLarge:
+              value:
+                code: InvalidArgument
+                message: The content of the request was too large.
     InternalServerError: # 500
       description: An internal server error occurred
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            InternalServerError:
+              value:
+                code: Internal
+                message: An internal error occurred.
     ServiceUnavailable: # 503
       description: One of the underlying services was not available
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            ServiceUnavailable:
+              value:
+                code: UnderlyingServiceUnavailable
+                message: One of the underlying services were not available.
     GatewayTimeout: # 504
       description: The request timed out
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            GatewayTimeout:
+              value:
+                code: RequestCanceled
+                message: The request deadline was exceeded.
   schemas:
     LookupInOperation:
       type: object
@@ -730,7 +796,7 @@ components:
         - None
         - Majority
         - MajorityAndPersistOnMaster
-        - PersitToMajority
+        - PersistToMajority
       x-enum-varnames:
         - DurabilityLevelNone
         - DurabilityLevelMajority
@@ -972,7 +1038,7 @@ components:
       schema:
         type: string
     Expires:
-      description: The expiry time of the document represented as an ISO8601 string.
+      description: The expiry time of the document represented as an HTTP Date header.
       schema:
         type: string
     DocumentFlags:

--- a/dataapiv1/spec.yaml
+++ b/dataapiv1/spec.yaml
@@ -844,10 +844,13 @@ components:
         path:
           description: That path within the document to perform the operation on.
           type: string
+          example: "address"
     LookupInOperationResult:
       type: object
       properties:
-        value: {}
+        value:
+          example: "Madeira Dr, Brighton BN2 1TW"
+          description: "The value contained in the specified field"
         error:
           $ref: '#/components/schemas/SubdocError'
     MutateInOperation:
@@ -858,10 +861,12 @@ components:
         path:
           description: That path within the document to perform the operation on.
           type: string
+          example: "hours"
         value:
           description: The value to use for the sub-document operation.
           type: object
           x-go-type: json.RawMessage
+          example: "10am-8pm"
     MutateInOperationResult:
       type: object
       properties:
@@ -919,6 +924,7 @@ components:
       required:
         - error
         - message
+      example: null
     ErrorCode:
       title: ErrorCode
       description: ErrorCode specifies the more specified error that occurred.
@@ -1043,6 +1049,7 @@ components:
         - MutateInOperationTypeArrayInsert
         - MutateInOperationTypeArrayAddUnique
         - MutateInOperationTypeCounter
+      example: Upsert
   parameters:
     AuthorizationHeader:
       in: header

--- a/dataapiv1/spec.yaml
+++ b/dataapiv1/spec.yaml
@@ -93,12 +93,26 @@ paths:
                   "city": "Brighton",
                   "state": null
                 }
-            '*':
+            'text/plain':
+              example: "Here is the text that was contained in the specified document."
+              schema:
+                type: string
+                description: The text contained within the document.
+                example: Here is the contents of your document
+            'application/octet-stream':
+              example: |- 
+                01001000011001010111001001100101001000000110100101110011 
+                00100000011101000110100001100101001000000110001001101001 
+                01101110011000010111001001111001001000000110001101101111 
+                01101110011101000110010101101110011101000111001100100000 
+                01101111011001100010000001110100011010000110010100100000 
+                01110011011100000110010101100011011010010110011001101001 
+                01100101011001000010000001100100011011110110001101110101 
+                0110110101100101011011100111010000101110
               schema:
                 type: string
                 format: binary
-                description: The contents of the document.
-                example: "Here is the contents of your document"
+                description: The binary contents of the document.
         '400':
           $ref: '#/components/responses/BadRequest' 
         '403':
@@ -621,11 +635,26 @@ paths:
                   "city": "Brighton",
                   "state": null
                 }
-            '*':
+            'text/plain':
+              example: "Here is the text that was contained in the specified document."
+              schema:
+                type: string
+                description: The text contained within the document.
+                example: Here is the contents of your document
+            'application/octet-stream':
+              example: |-
+                01001000011001010111001001100101001000000110100101110011 
+                00100000011101000110100001100101001000000110001001101001 
+                01101110011000010111001001111001001000000110001101101111 
+                01101110011101000110010101101110011101000111001100100000 
+                01101111011001100010000001110100011010000110010100100000 
+                01110011011100000110010101100011011010010110011001101001 
+                01100101011001000010000001100100011011110110001101110101 
+                0110110101100101011011100111010000101110
               schema:
                 type: string
                 format: binary
-                description: The contents of the document.
+                description: The binary contents of the document.
         '202':
           description: Successful updated the expiry of the document but is not returning the content of the document.
           headers:

--- a/dataapiv1/spec.yaml
+++ b/dataapiv1/spec.yaml
@@ -66,7 +66,33 @@ paths:
               schema:
                 type: object
                 description: The contents of the document.
-                example: { "hello": "world", "success": true}
+                example: {
+                  "title": "Brighton",
+                  "name": "Brighton Palace Pier",
+                  "alt": null,
+                  "address": "Madeira Dr, Brighton BN2 1TW",
+                  "directions": null,
+                  "phone": "01273609361",
+                  "tollfree": null,
+                  "email": "info@brightonpalacepier.co.uk",
+                  "url": "https://www.brightonpier.co.uk",
+                  "hours": "11am–6pm",
+                  "image": null,
+                  "price": "£2",
+                  "content": "The Brighton Palace Pier, commonly known as Brighton Pier or the Palace Pier, is a Grade II listed pleasure pier in Brighton, England, located in the city centre opposite the Old Steine. 
+                               Established in 1899, it was the third pier to be constructed in Brighton after the Royal Suspension Chain Pier and the West Pier, but is now the only one still in operation.",
+                  "geo": {
+                    "lat": 50.815,
+                    "lon": -0.136944,
+                    "accuracy": "RANGE_INTERPOLATED"
+                  },
+                  "activity": "do",
+                  "type": "landmark",
+                  "id": 10044,
+                  "country": "United Kingdom",
+                  "city": "Brighton",
+                  "state": null
+                }
             '*':
               schema:
                 type: string
@@ -443,6 +469,37 @@ paths:
             X-CB-Flags:
               $ref: "#/components/headers/DocumentFlags"
           content:
+            'application/json':
+              schema:
+                type: object
+                description: The contents of the document.
+                example: {
+                  "title": "Brighton",
+                  "name": "Brighton Palace Pier",
+                  "alt": null,
+                  "address": "Madeira Dr, Brighton BN2 1TW",
+                  "directions": null,
+                  "phone": "01273609361",
+                  "tollfree": null,
+                  "email": "info@brightonpalacepier.co.uk",
+                  "url": "https://www.brightonpier.co.uk",
+                  "hours": "11am–6pm",
+                  "image": null,
+                  "price": "£2",
+                  "content": "The Brighton Palace Pier, commonly known as Brighton Pier or the Palace Pier, is a Grade II listed pleasure pier in Brighton, England, located in the city centre opposite the Old Steine. 
+                               Established in 1899, it was the third pier to be constructed in Brighton after the Royal Suspension Chain Pier and the West Pier, but is now the only one still in operation.",
+                  "geo": {
+                    "lat": 50.815,
+                    "lon": -0.136944,
+                    "accuracy": "RANGE_INTERPOLATED"
+                  },
+                  "activity": "do",
+                  "type": "landmark",
+                  "id": 10044,
+                  "country": "United Kingdom",
+                  "city": "Brighton",
+                  "state": null
+                }
             '*':
               schema:
                 type: string
@@ -533,6 +590,37 @@ paths:
             X-CB-Flags:
               $ref: "#/components/headers/DocumentFlags"
           content:
+            'application/json':
+              schema:
+                type: object
+                description: The contents of the document.
+                example: {
+                  "title": "Brighton",
+                  "name": "Brighton Palace Pier",
+                  "alt": null,
+                  "address": "Madeira Dr, Brighton BN2 1TW",
+                  "directions": null,
+                  "phone": "01273609361",
+                  "tollfree": null,
+                  "email": "info@brightonpalacepier.co.uk",
+                  "url": "https://www.brightonpier.co.uk",
+                  "hours": "11am–6pm",
+                  "image": null,
+                  "price": "£2",
+                  "content": "The Brighton Palace Pier, commonly known as Brighton Pier or the Palace Pier, is a Grade II listed pleasure pier in Brighton, England, located in the city centre opposite the Old Steine. 
+                               Established in 1899, it was the third pier to be constructed in Brighton after the Royal Suspension Chain Pier and the West Pier, but is now the only one still in operation.",
+                  "geo": {
+                    "lat": 50.815,
+                    "lon": -0.136944,
+                    "accuracy": "RANGE_INTERPOLATED"
+                  },
+                  "activity": "do",
+                  "type": "landmark",
+                  "id": 10044,
+                  "country": "United Kingdom",
+                  "city": "Brighton",
+                  "state": null
+                }
             '*':
               schema:
                 type: string

--- a/gateway/dapiimpl/server_v1/helpers.go
+++ b/gateway/dapiimpl/server_v1/helpers.go
@@ -61,7 +61,7 @@ func durabilityLevelToMemdx(dl dataapiv1.DurabilityLevel) (memdx.DurabilityLevel
 		return memdx.DurabilityLevelMajority, nil
 	case dataapiv1.DurabilityLevelMajorityAndPersistOnMaster:
 		return memdx.DurabilityLevelMajorityAndPersistToActive, nil
-	case dataapiv1.DurabilityLevelPersitToMajority:
+	case dataapiv1.DurabilityLevelPersistToMajority:
 		return memdx.DurabilityLevelPersistToMajority, nil
 	}
 


### PR DESCRIPTION
This PR improves the Data API by adding descriptions and examples to the requests and responses to make the generated documentation more useful. The documentation can be generated using redocly in the home directory using:

`redocly preview-docs ./dataapiv1/spec.yaml`
