### PR TITLE
ING-1235: Bump go version used in testing to 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24
       - uses: arduino/setup-protoc@v3
         with:
           version: 31.1


### PR DESCRIPTION
This PR bumps the go version to that used by the build team to build the binaries.