### PR TITLE
ING-1115: Only return GetAllReplicas error once the stream is closed

### DIFF
--- a/gateway/dataimpl/server_v1/kvserver.go
+++ b/gateway/dataimpl/server_v1/kvserver.go
@@ -1332,13 +1332,16 @@ func (s *KvServer) GetAllReplicas(in *kv_v1.GetAllReplicasRequest, out kv_v1.KvS
 		}
 	}
 
+	var replicaError error
 	for {
 		res, err := replicaStream.Next()
 		if err != nil {
 			s.logger.Debug("error reading a replica", zap.Error(err))
-			return err
+			replicaError = err
+			continue
 		}
 
+		// If err and res both nil the stream has ended
 		if res == nil {
 			break
 		}
@@ -1353,7 +1356,7 @@ func (s *KvServer) GetAllReplicas(in *kv_v1.GetAllReplicasRequest, out kv_v1.KvS
 		}
 	}
 
-	return nil
+	return replicaError
 }
 
 func (s *KvServer) checkKey(key string) *status.Status {


### PR DESCRIPTION
This PR changes the behaviour of GetAllReplicas so that an error is only returned on the grpc stream once all the results have been returned from the underlying Gocbcorex stream. This is because when a non-nil error is returned on a GRPC stream the stream is aborted and no more results can be sent on it.