### PR TITLE
ING-1185: Remove comment referencing this issue

### DIFF
--- a/gateway/test/search_mgmt_test.go
+++ b/gateway/test/search_mgmt_test.go
@@ -491,7 +491,6 @@ func (s *GatewayOpsTestSuite) TestUpdateIndex() {
 			},
 			expect: codes.OK,
 		},
-		// TODO - ING-1185
 		{
 			description: "SourceParams",
 			modifyDefault: func(def *admin_search_v1.UpdateIndexRequest) *admin_search_v1.UpdateIndexRequest {


### PR DESCRIPTION
The test is no longer flaky due to Ensure Index being used, so we just need to get rid of the comment referencing the original issue. 