### PR TITLE
ING-1495: When creating/dropping a primary idx, call consistency helpers with '#primary'

### DIFF
--- a/gateway/dataimpl/server_v1/queryadminserver.go
+++ b/gateway/dataimpl/server_v1/queryadminserver.go
@@ -270,7 +270,7 @@ func (s *QueryIndexAdminServer) CreatePrimaryIndex(
 		BucketName:     in.BucketName,
 		ScopeName:      scopeName,
 		CollectionName: collectionName,
-		IndexName:      in.GetName(),
+		IndexName:      indexName,
 		OnBehalfOf:     oboInfo,
 	})
 	if err != nil {
@@ -402,11 +402,18 @@ func (s *QueryIndexAdminServer) DropPrimaryIndex(
 		return nil, errSt.Err()
 	}
 
+	var indexName string
+	if in.Name == nil {
+		indexName = "#primary"
+	} else {
+		indexName = *in.Name
+	}
+
 	err := agent.DropPrimaryIndex(ctx, &cbqueryx.DropPrimaryIndexOptions{
 		BucketName:        in.BucketName,
 		ScopeName:         in.GetScopeName(),
 		CollectionName:    in.GetCollectionName(),
-		IndexName:         in.GetName(),
+		IndexName:         indexName,
 		IgnoreIfNotExists: in.GetIgnoreIfMissing(),
 		OnBehalfOf:        oboInfo,
 	})
@@ -465,7 +472,7 @@ func (s *QueryIndexAdminServer) DropPrimaryIndex(
 		BucketName:     in.BucketName,
 		ScopeName:      scopeName,
 		CollectionName: collectionName,
-		IndexName:      in.GetName(),
+		IndexName:      indexName,
 		OnBehalfOf:     oboInfo,
 	})
 	if err != nil {

--- a/gateway/test/query_mgmt_test.go
+++ b/gateway/test/query_mgmt_test.go
@@ -47,6 +47,53 @@ func (s *GatewayOpsTestSuite) TestQueryManagement() {
 	}
 
 	s.Run("PrimaryIndex", func() {
+		s.Run("CreateAndDropWithUnsetName", func() {
+			creds := s.basicRpcCreds
+
+			// First let's attempt a drop in case the primary index exists already
+			{
+				resp, err := queryAdminClient.DropPrimaryIndex(context.Background(),
+					&admin_query_v1.DropPrimaryIndexRequest{
+						Name:            nil,
+						BucketName:      s.bucketName,
+						ScopeName:       &s.scopeName,
+						CollectionName:  &s.collectionName,
+						IgnoreIfMissing: &trueBool,
+					},
+					grpc.PerRPCCredentials(creds))
+
+				requireRpcSuccess(s.T(), resp, err)
+			}
+
+			// Create the index
+			{
+				resp, err := queryAdminClient.CreatePrimaryIndex(context.Background(),
+					&admin_query_v1.CreatePrimaryIndexRequest{
+						BucketName:     s.bucketName,
+						Name:           nil,
+						ScopeName:      &s.scopeName,
+						CollectionName: &s.collectionName,
+					},
+					grpc.PerRPCCredentials(creds))
+
+				requireRpcSuccess(s.T(), resp, err)
+			}
+
+			// Drop it again, this time without IgnoreIfMissing, it must exist.
+			{
+				resp, err := queryAdminClient.DropPrimaryIndex(context.Background(),
+					&admin_query_v1.DropPrimaryIndexRequest{
+						Name:           nil,
+						BucketName:     s.bucketName,
+						ScopeName:      &s.scopeName,
+						CollectionName: &s.collectionName,
+					},
+					grpc.PerRPCCredentials(creds))
+
+				requireRpcSuccess(s.T(), resp, err)
+			}
+		})
+
 		indexName := uuid.NewString()
 
 		s.Run("Create", func() {


### PR DESCRIPTION
After creating a primary index with no custom name (i.e. the name is #primary), `EnsureQueryIndexCreated` is called with the empty string as the name, instead of setting it to `#primary`. This means that the `EnsureQueryIndexCreated` call, and the overall `CreatePrimaryIndex` RPC call, don't return, until timeout.